### PR TITLE
Detect command environment

### DIFF
--- a/src/objprint/frame_analyzer.py
+++ b/src/objprint/frame_analyzer.py
@@ -104,18 +104,14 @@ class FrameAnalyzer:
         return lines
 
     def return_object(self, frame: Optional[FrameType]) -> bool:
+        current_frame = frame
+        while current_frame:
+            filename = current_frame.f_code.co_filename
+            if filename in ["<stdin>", "<console>"]:
+                return False
+            current_frame = current_frame.f_back
         if frame is None:
             return True
-        try:
-            current_frame: Optional[FrameType] = frame
-            while current_frame:
-                filename = current_frame.f_code.co_filename
-                if filename == "<stdin>" or filename == "<console>":
-                    return False
-                current_frame = current_frame.f_back
-        except AttributeError:  # pragma: no cover
-            pass  # pragma: no cover
-
         node: Optional[ast.AST] = Source.executing(frame).node
         if node is None:
             return True

--- a/src/objprint/frame_analyzer.py
+++ b/src/objprint/frame_analyzer.py
@@ -112,7 +112,7 @@ class FrameAnalyzer:
             current_frame: Optional[FrameType] = frame
             while current_frame:
                 filename = current_frame.f_code.co_filename
-                if filename == "<stdin>":
+                if filename == "<stdin>" or filename == "<console>":
                     return False  # This means the code is running is REPL
                 current_frame = current_frame.f_back
         except AttributeError:

--- a/src/objprint/frame_analyzer.py
+++ b/src/objprint/frame_analyzer.py
@@ -104,14 +104,15 @@ class FrameAnalyzer:
         return lines
 
     def return_object(self, frame: Optional[FrameType]) -> bool:
-        current_frame = frame
+        if frame is None:
+            return True
+        current_frame: Optional[FrameType] = frame
         while current_frame:
             filename = current_frame.f_code.co_filename
             if filename in ["<stdin>", "<console>"]:
                 return False
             current_frame = current_frame.f_back
-        if frame is None:
-            return True
+
         node: Optional[ast.AST] = Source.executing(frame).node
         if node is None:
             return True
@@ -120,5 +121,4 @@ class FrameAnalyzer:
         for stmt in statement_node:
             if isinstance(stmt, ast.Expr) and node == stmt.value:
                 return False
-
         return True

--- a/src/objprint/frame_analyzer.py
+++ b/src/objprint/frame_analyzer.py
@@ -106,19 +106,16 @@ class FrameAnalyzer:
     def return_object(self, frame: Optional[FrameType]) -> bool:
         if frame is None:
             return True
-
-        # check if environment is in REPL
         try:
             current_frame: Optional[FrameType] = frame
             while current_frame:
                 filename = current_frame.f_code.co_filename
                 if filename == "<stdin>" or filename == "<console>":
-                    return False  # This means the code is running is REPL
+                    return False
                 current_frame = current_frame.f_back
-        except AttributeError:
-            pass
+        except AttributeError:  # pragma: no cover
+            pass  # pragma: no cover
 
-        # check if function call is a direct call whose output will not be used as an argument
         node: Optional[ast.AST] = Source.executing(frame).node
         if node is None:
             return True

--- a/src/objprint/frame_analyzer.py
+++ b/src/objprint/frame_analyzer.py
@@ -102,3 +102,31 @@ class FrameAnalyzer:
         if next_line:
             lines.append(next_line)
         return lines
+
+    def return_object(self, frame: Optional[FrameType]) -> bool:
+        if frame is None:
+            print("frame is none")
+            return True
+        print(frame)
+        node: Optional[ast.AST] = Source.executing(frame).node
+        if node is None:
+            print("node is none")
+            return True
+        lineno = inspect.getlineno(frame)
+        stat = Source.for_frame(frame).statements_at_line(lineno)
+        print(stat)
+        for s in stat:
+            if node in s.value.args:
+                return True
+
+        try:
+            while frame:
+                filename = frame.f_code.co_filename
+                print(filename)
+                if filename == "<stdin>" or filename.startswith("<ipython-input"):
+                    return False  # This means the code is running is REPL
+                frame = frame.f_back
+        finally:
+            del frame
+
+        return False

--- a/src/objprint/objprint.py
+++ b/src/objprint/objprint.py
@@ -70,20 +70,13 @@ class ObjPrint:
         }
         self._sys_print = print
         self.frame_analyzer = FrameAnalyzer()
-        self.call_depth = 0
-        self.max_call_depth = 0
 
     def __call__(self, *objs: Any, file: Any = None, format: str = "string", **kwargs) -> Any:
-
-        self.call_depth += 1
-        self.max_call_depth += 1
-
         cfg = self._configs.overwrite(**kwargs)
         if cfg.enable:
             # if inspect.currentframe() returns None, set call_frame to None
             # and let the callees handle it
             call_frame = inspect.currentframe()
-
             if call_frame is not None:
                 call_frame = call_frame.f_back
 
@@ -344,17 +337,3 @@ class ObjPrint:
         else:
             s = ", ".join(elems)
             return f"{header}{s}{footer}"
-
-    def _return_object(self) -> bool:
-        frame = inspect.currentframe()
-
-        try:
-            while frame:
-                filename = frame.f_code.co_filename
-                if filename == "<stdin>" or filename.startswith("<ipython-input"):
-                    return False  # This means the code is running is REPL
-                frame = frame.f_back
-        finally:
-            del frame
-
-        return True

--- a/tests/test_objprint.py
+++ b/tests/test_objprint.py
@@ -5,7 +5,6 @@
 import code
 from contextlib import redirect_stdout
 import io
-from ipykernel.kernelbase import Kernel
 import json
 import re
 from unittest.mock import patch
@@ -319,7 +318,7 @@ class TestObjprint(ObjprintTestCase):
         with self.assertRaises(TypeError):
             op({}, exclude="invalid")
 
-    def test_interactive_console_return_value(self):
+    def test_console_return_value(self):
         with io.StringIO() as buf, redirect_stdout(buf):
             console = code.InteractiveConsole()
             console.push("from objprint import op")
@@ -327,25 +326,22 @@ class TestObjprint(ObjprintTestCase):
             output = buf.getvalue()
         self.assertEqual("[1, 2, 3]\n", output)
 
-    def test_jupyter_notebook_return_value(self):
+    def test_exec_return_value(self):
         with io.StringIO() as buf, redirect_stdout(buf):
-            kernel = Kernel()
             exec("from objprint import op")
             exec("op([1,2,3])")
             output = buf.getvalue()
         self.assertEqual("[1, 2, 3]\n", output)
-        
+
         with io.StringIO() as buf, redirect_stdout(buf):
-            kernel = Kernel()
             exec("from objprint import op")
             exec("op(op([1,2,3]))")
             output = buf.getvalue()
         self.assertEqual("[1, 2, 3]\n[1, 2, 3]\n", output)
 
         with io.StringIO() as buf, redirect_stdout(buf):
-            kernel = Kernel()
             exec("from objprint import op")
             exec("b = op([1,2,3])")
-            exec("b")
+            exec("print(b)")
             output = buf.getvalue()
-        self.assertEqual("[1, 2, 3]\n", output)
+        self.assertEqual("[1, 2, 3]\n[1, 2, 3]\n", output)


### PR DESCRIPTION
## Related Issues
This PR attempts to resolve issue #73.

## Description
This PR updates the behavior of the `op()` function based on the environment in which it is called.

In the case of a REPL environment, the `op()` function will always return `None`. This makes calling chains impossible, but it is the best that can be done given that `Source.executing(frame).node` cannot return a valid node in a REPL environment.

In other environments, such as Jupyter Notebook and scripts, the `op()` function will check whether it is called directly to decide whether it should return `None` or the objects. The following are examples of different return values:

```
op(a)    # return None
op(op(a))  # outer op() returns None, inner op() returns object
b = op(a)  # return objects
```

This change helps prevent printing twice in the Jupyter Notebook case.

In the case where `op()` is disabled, it will just return the object, regardless of the environment.

## Changes Made
Add a new function named `return_object()`, which checks the frame `op()` is called to decide whether this call should return objects or `None`.
Created unit tests to verify the new behavior of the op() function

## Testing
For the unittest section, since I don't know how to perfectly simulate the REPL and Jupyter Notebook environments, `console` and `exec()` are used as replacements. I am open to opinions on how to make the tests closer to real-world scenarios.

