### PR TITLE
Custom number representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ that match exclusive check.
 * ``elements(-1)`` - the maximum number of elements that will be displayed, ``-1`` means no restriction
 * ``color(True)`` - whether to use colored scheme
 * ``line_number(False)`` - whether to print the ``function (filename:line_number)`` before printing the object
+* ``number_format('d')`` - the format to print integer values, ``'h'`` for hex, ``'b'`` for binary, and ``'o'`` for octal representation
 * ``arg_name(False)`` - whether to print the argument expression before the argument value
 * ``skip_recursion(True)`` - whether skip printing recursive data, which would cause infinite recursion without ``depth`` constraint
 * ``honor_existing(True)`` - whether to use the existing user defined ``__repr__`` or ``__str__`` method

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ that match exclusive check.
 * ``elements(-1)`` - the maximum number of elements that will be displayed, ``-1`` means no restriction
 * ``color(True)`` - whether to use colored scheme
 * ``line_number(False)`` - whether to print the ``function (filename:line_number)`` before printing the object
-* ``number_format('d')`` - the format to print integer values, ``'h'`` for hex, ``'b'`` for binary, and ``'o'`` for octal representation
+* ``number_format('d')`` - the format to print integer values, ``'d'`` for decimal, ``'h'`` for hex, ``'b'`` for binary, and ``'o'`` for octal representation
 * ``arg_name(False)`` - whether to print the argument expression before the argument value
 * ``skip_recursion(True)`` - whether skip printing recursive data, which would cause infinite recursion without ``depth`` constraint
 * ``honor_existing(True)`` - whether to use the existing user defined ``__repr__`` or ``__str__`` method

--- a/src/objprint/objprint.py
+++ b/src/objprint/objprint.py
@@ -32,6 +32,7 @@ class _PrintConfig:
     print_methods: bool = False
     skip_recursion: bool = True
     honor_existing: bool = True
+    number_format: str = 'd'
 
     def __init__(self, **kwargs):
         for key, val in kwargs.items():
@@ -133,9 +134,9 @@ class ObjPrint:
         # If it's builtin type, return it directly
         if isinstance(obj, str):
             return f"'{obj}'"
-        elif isinstance(obj, int) or \
-                isinstance(obj, float) or \
-                obj is None:
+        elif isinstance(obj, int):
+            return self._get_number_format(obj, cfg)
+        elif isinstance(obj, float) or obj is None:
             return str(obj)
         elif isinstance(obj, FunctionType):
             return f"<function {obj.__name__}>"
@@ -149,7 +150,7 @@ class ObjPrint:
             memo = memo.copy()
             memo.add(id(obj))
 
-        if isinstance(obj, list) or isinstance(obj, tuple) or isinstance(obj, set):
+        if isinstance(obj, (list, tuple, set)):
             elems = (f"{self._objstr(val, memo, indent_level + 1, cfg)}" for val in obj)
         elif isinstance(obj, dict):
             items = [(key, val) for key, val in obj.items()]
@@ -337,3 +338,15 @@ class ObjPrint:
         else:
             s = ", ".join(elems)
             return f"{header}{s}{footer}"
+
+    def _get_number_format(self, number: int, cfg: _PrintConfig) -> str:
+        if cfg.number_format in ['d', 'dec', 'decimal']:
+            return str(number)
+        elif cfg.number_format in ['h', 'hex', 'hexadecimal']:
+            return hex(number)
+        elif cfg.number_format in ['b', 'bin', 'binary']:
+            return bin(number)
+        elif cfg.number_format in ['o', 'oct', 'octal']:
+            return oct(number)
+        else:
+            return str(number)

--- a/src/objprint/objprint.py
+++ b/src/objprint/objprint.py
@@ -32,7 +32,7 @@ class _PrintConfig:
     print_methods: bool = False
     skip_recursion: bool = True
     honor_existing: bool = True
-    number_format: str = 'd'
+    number_format: str = 'decimal'
 
     def __init__(self, **kwargs):
         for key, val in kwargs.items():

--- a/tests/test_objstr.py
+++ b/tests/test_objstr.py
@@ -171,3 +171,12 @@ class TestObjStr(ObjprintTestCase):
         self.assertEqual(s.count("t2"), 1)
         s = objstr(t2, skip_recursion=False, depth=6)
         self.assertEqual(s.count("t2"), 3)
+
+    def test_number_format(self):
+        t1  = [11,12,13]
+        s_bin = objstr(t1, number_format='b')
+        s_oct = objstr(t1, number_format='o')
+        s_hex = objstr(t1, number_format='h')
+        self.assertEqual(s_bin, "[0b1011, 0b1100, 0b1101]")
+        self.assertEqual(s_oct, "[0o13, 0o14, 0o15]")
+        self.assertEqual(s_hex, "[0xb, 0xc, 0xd]")

--- a/tests/test_objstr.py
+++ b/tests/test_objstr.py
@@ -173,7 +173,7 @@ class TestObjStr(ObjprintTestCase):
         self.assertEqual(s.count("t2"), 3)
 
     def test_number_format(self):
-        t1  = [11,12,13]
+        t1 = [11, 12, 13]
         s_bin = objstr(t1, number_format='b')
         s_oct = objstr(t1, number_format='o')
         s_hex = objstr(t1, number_format='h')

--- a/tests/test_objstr.py
+++ b/tests/test_objstr.py
@@ -176,7 +176,11 @@ class TestObjStr(ObjprintTestCase):
         t1 = [11, 12, 13]
         s_bin = objstr(t1, number_format='b')
         s_oct = objstr(t1, number_format='o')
+        s_dec = objstr(t1, number_format='d')
         s_hex = objstr(t1, number_format='h')
+        s_invalid = objstr(t1, number_format='invalid')
         self.assertEqual(s_bin, "[0b1011, 0b1100, 0b1101]")
         self.assertEqual(s_oct, "[0o13, 0o14, 0o15]")
+        self.assertEqual(s_dec, "[11, 12, 13]")
         self.assertEqual(s_hex, "[0xb, 0xc, 0xd]")
+        self.assertEqual(s_invalid, "[11, 12, 13]")


### PR DESCRIPTION
## Related Issue
This PR solves Issue #77 

## Description
I add a new argument, `number_format`, which takes a string. The string is to specify which representation to print integers, currently supporting:
decimal(default) - `'d', 'dec', 'decimal'`;
hex - `'h', 'hex', 'hexadecimal'` ; 
binary - `'b', 'bin', 'binary'`;
octal - `'o', 'oct', 'octal'`.

## Future Patches
Is supporting this feature with objjson() desired?

