### PR TITLE
Register type format

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,18 @@ Print B with Base Class Formatter
 >
 ```
 
+If you want to inspect all the registered functions, you can use the ```list_formatter()``` method.
+
+```python
+op.list_formatter()
+```
+
+```
+{
+  BaseClass : base_formatter()
+}
+```
+
 Please note that registering a formatter function with ```op``` will affect the output of ```objprint``` and ```objstr``` methods in the same way. The changes will persist until the formatter is unregistered or ```Objprint``` is reset.
 
 ### config

--- a/README.md
+++ b/README.md
@@ -285,6 +285,31 @@ that match exclusive check.
 
 ```attr_pattern```, ```include``` and ```exclude``` arguments work on ```objprint```, ```objstr``` and ```@add_objprint```.
 
+### Register Custom Type Formatter
+
+You can also customize how certain types of objects are displayed by registering a custom formatter function to transform an object of a specific type into a string. For example, you can print all integers in hexadecimal format by registering the ```hex()``` function for the ```int``` data type. You can always unregister the formatter function if you no longer want to use it.
+
+```python
+from objprint import op
+
+op.register(int, hex)
+op(10)  # prints 0xa
+op.unregister(int)
+op(10)  # prints 10
+```
+
+Alternatively, you can use a decorator to register a custom formatter function:
+
+```python
+@op.register_type(str)
+def custom_formatter(obj: str):
+    return f"custom_print: {obj}"
+```
+
+```Objprint``` always prioritizes custom formatters over default formatters and will use the registered functions if they exist. If type annotations are provided in the custom formatter functions, ```Objprint``` will also perform a validation check to ensure the provided function accepts the specified data type as input and returns a string.
+
+Note that when you register a function with ```op```, the result for ```objprint```, ```objstr``` will also be affected in the same way.
+
 ### config
 
 ```objprint``` formats the output based on some configs

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ With ```inherit=False```, derived class will use the default formatter provided 
 def base_formatter(obj: BaseClass) -> str:
     return f'Print {obj.name} with Base Class Formatter'
 
-op(DerivedClass(), inherit=False)
+op(DerivedClass())
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ def custom_formatter(obj: str):
 op("hi")  # prints custom_print: hi
 ```
 
-During registration, ```objprint``` will examined the specified object type, and raise a ```TypeError``` if an invalid object type is provided.
+During registration, ```objprint``` will examine the specified object type, and raise a ```TypeError``` if an invalid object type is provided.
 
 When you finish using the custom formatters, you can unregister them with ```unregister_formatter()```.
 

--- a/src/objprint/objprint.py
+++ b/src/objprint/objprint.py
@@ -2,6 +2,7 @@
 # For details: https://github.com/gaogaotiantian/objprint/blob/master/NOTICE.txt
 
 
+from collections import namedtuple
 import inspect
 import itertools
 import json
@@ -32,7 +33,6 @@ class _PrintConfig:
     print_methods: bool = False
     skip_recursion: bool = True
     honor_existing: bool = True
-    inherit: bool = True
 
     def __init__(self, **kwargs):
         for key, val in kwargs.items():
@@ -60,6 +60,8 @@ class _PrintConfig:
 
 
 class ObjPrint:
+    FormatterInfo = namedtuple('FormatterInfo', ['formatter', 'inherit'])
+
     def __init__(self):
         self._configs = _PrintConfig()
 
@@ -133,15 +135,20 @@ class ObjPrint:
 
     def _objstr(self, obj: Any, memo: Optional[Set[int]], indent_level: int, cfg: _PrintConfig) -> str:
         # If a custom formatter is registered for the object's type, use it directly
-        if cfg.inherit and self.type_formatter:
+        if self.type_formatter:
             obj_type = type(obj)
             for cls in obj_type.__mro__:
-                if cls in self.type_formatter:
-                    return self.type_formatter[cls](obj)
+                if cls in self.type_formatter and (
+                    cls == obj_type or self.type_formatter[cls].inherit
+                ):
+                    return self.type_formatter[cls].formatter(obj)
+
         # If it's builtin type, return it directly
         if isinstance(obj, str):
             return f"'{obj}'"
-        elif isinstance(obj, (int, float)) or obj is None:
+        elif isinstance(obj, int) or \
+                isinstance(obj, float) or \
+                obj is None:
             return str(obj)
         elif isinstance(obj, FunctionType):
             return f"<function {obj.__name__}>"
@@ -155,7 +162,7 @@ class ObjPrint:
             memo = memo.copy()
             memo.add(id(obj))
 
-        if isinstance(obj, (list, tuple, set)):
+        if isinstance(obj, list) or isinstance(obj, tuple) or isinstance(obj, set):
             elems = (f"{self._objstr(val, memo, indent_level + 1, cfg)}" for val in obj)
         elif isinstance(obj, dict):
             items = [(key, val) for key, val in obj.items()]
@@ -288,15 +295,20 @@ class ObjPrint:
     def register_formatter(
         self,
         obj_type: Type[Any],
-        obj_formatter: Optional[Callable[[Any], str]] = None
+        obj_formatter: Optional[Callable[[Any], str]] = None,
+        inherit: bool = True
     ) -> Optional[Callable[[Callable[[Any], str]], Callable[[Any], str]]]:
         if obj_formatter is None:
             def wrapper(obj_formatter: Callable[[Any], str]) -> Callable[[Any], str]:
-                self.register_formatter(obj_type, obj_formatter)
+                self.register_formatter(obj_type, obj_formatter, inherit)
                 return obj_formatter
             return wrapper
-        self._validate_formatter(obj_type, obj_formatter)
-        self.type_formatter[obj_type] = obj_formatter
+
+        if not isinstance(obj_type, type):
+            raise TypeError("obj_type must be a type")
+
+        fmt_info = self.FormatterInfo(formatter=obj_formatter, inherit=inherit)
+        self.type_formatter[obj_type] = fmt_info
         return None
 
     def unregister_formatter(self, *obj_types: Type[Any]) -> None:
@@ -307,23 +319,8 @@ class ObjPrint:
                 if obj_type in self.type_formatter:
                     del self.type_formatter[obj_type]
 
-    def list_formatter(self, print_list: bool = True) -> Optional[dict]:
-        if print_list and self._configs.enable:
-            formatter_content = ["{"]
-            for obj_type, obj_formatter in self.type_formatter.items():
-                formatter_content.append(
-                    f"    {obj_type.__name__} : "
-                    f"{obj_formatter.__name__}()")
-            formatter_content.append("}")
-            formatter_str = '\n'.join(formatter_content)
-            self._sys_print(formatter_str)
-        call_frame = inspect.currentframe()
-        if call_frame is not None:
-            call_frame = call_frame.f_back
-        if self.frame_analyzer.return_object(call_frame):
-            return self.type_formatter
-        else:
-            return None
+    def get_formatter(self) -> dict:
+        return self.type_formatter
 
     def _get_header_footer(self, obj: Any, cfg: _PrintConfig):
         obj_type = type(obj)
@@ -383,27 +380,3 @@ class ObjPrint:
         else:
             s = ", ".join(elems)
             return f"{header}{s}{footer}"
-
-    def _validate_formatter(
-            self,
-            obj_type: Type[Any],
-            obj_formatter: Callable[[Any], str]) -> None:
-        if not isinstance(obj_type, type):
-            raise TypeError("obj_type must be a type")
-
-        if inspect.isbuiltin(obj_formatter):
-            return
-
-        # check signature for custom formatter function
-        # if type annotation is provided, then check whether they meet requirements
-        signature = inspect.signature(obj_formatter)
-        parameters = list(signature.parameters.values())
-
-        if len(parameters) != 1:
-            raise TypeError("The provided formatter must accept exactly one argument")
-
-        if parameters[0].annotation not in [inspect.Parameter.empty, obj_type]:
-            raise TypeError("The provided formatter's argument type must match the specified obj_type")
-
-        if signature.return_annotation not in [inspect.Parameter.empty, str]:
-            raise TypeError("The provided formatter must return a string")

--- a/src/objprint/objprint.py
+++ b/src/objprint/objprint.py
@@ -298,7 +298,7 @@ class ObjPrint:
             return obj_formatter
         return wrapper
 
-    def unregister(self, obj_type: type) -> None:
+    def unregister(self, obj_type: Type[Any]) -> None:
         if obj_type in self.type_formatter:
             del self.type_formatter[obj_type]
 

--- a/src/objprint/objprint.py
+++ b/src/objprint/objprint.py
@@ -308,11 +308,11 @@ class ObjPrint:
                     del self.type_formatter[obj_type]
 
     def list_formatter(self, print_list: bool = True) -> Optional[dict]:
-        if print_list:
+        if print_list and self._configs.enable:
             formatter_content = ["{"]
             for obj_type, obj_formatter in self.type_formatter.items():
                 formatter_content.append(
-                    f"{obj_type.__name__} : "
+                    f"    {obj_type.__name__} : "
                     f"{obj_formatter.__name__}()")
             formatter_content.append("}")
             formatter_str = '\n'.join(formatter_content)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -77,10 +77,6 @@ class TestBasic(ObjprintTestCase):
             self.assertEqual(buf.getvalue(), "Float: 3.142\n")
         op.unregister_formatter(int, float)
 
-        with io.StringIO() as buf, redirect_stdout(buf):
-            op(a)
-            self.assertEqual(buf.getvalue(), "[10, 13, 16]\n")
-
         @op.register_formatter(str)
         def custom_formatter(obj: str) -> str:
             return f"custom_format: {obj}"
@@ -88,21 +84,10 @@ class TestBasic(ObjprintTestCase):
             op('string')
             self.assertEqual(buf.getvalue(), "custom_format: string\n")
 
-        with io.StringIO() as buf, redirect_stdout(buf):
-            op.list_formatter()
-            self.assertEqual(buf.getvalue(), "{\n    str : custom_formatter()\n}\n")
         op.unregister_formatter()
 
         with io.StringIO() as buf, redirect_stdout(buf):
-            output = op.list_formatter()
-            self.assertEqual(buf.getvalue(), "{\n}\n")
+            output = op.get_formatter()
             self.assertEqual(output, {})
 
-    def test_invalid_formatter(self):
         self.assertRaises(TypeError, lambda: op.register_formatter(1, hex))
-        self.assertRaises(TypeError, lambda: op.register_formatter(int, lambda x, y: str(x)))
-
-        def invalid_formatter(obj: int) -> int:
-            return obj
-        self.assertRaises(TypeError, lambda: op.register_formatter(str, invalid_formatter))
-        self.assertRaises(TypeError, lambda: op.register_formatter(int, invalid_formatter))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -63,3 +63,23 @@ class TestBasic(ObjprintTestCase):
         with io.StringIO() as buf, redirect_stdout(buf):
             op(A())
             self.assertTrue(len(buf.getvalue()) > 0)
+
+    def test_register(self):
+        a = [10, 13, 16]
+        op.register(int, hex)
+        with io.StringIO() as buf, redirect_stdout(buf):
+            op(a)
+            self.assertEqual(buf.getvalue(), "[0xa, 0xd, 0x10]\n")
+
+        op.unregister(int)
+        with io.StringIO() as buf, redirect_stdout(buf):
+            op(a)
+            self.assertEqual(buf.getvalue(), "[10, 13, 16]\n")
+
+        @op.register_type(str)
+        def custom_formatter(obj: str) -> str:
+            return f"custom_format: {obj}"
+        with io.StringIO() as buf, redirect_stdout(buf):
+            op('string')
+            self.assertEqual(buf.getvalue(), "custom_format: string\n")
+        op.unregister(str)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -90,7 +90,7 @@ class TestBasic(ObjprintTestCase):
 
         with io.StringIO() as buf, redirect_stdout(buf):
             op.list_formatter()
-            self.assertEqual(buf.getvalue(), "{\nstr : custom_formatter()\n}\n")
+            self.assertEqual(buf.getvalue(), "{\n    str : custom_formatter()\n}\n")
         op.unregister_formatter()
 
         with io.StringIO() as buf, redirect_stdout(buf):

--- a/tests/test_objprint.py
+++ b/tests/test_objprint.py
@@ -358,7 +358,7 @@ class TestObjprint(ObjprintTestCase):
             return obj.name
 
         with io.StringIO() as buf, redirect_stdout(buf):
-            op(DerivedClass(), inherit=True)
+            op(DerivedClass())
             output = buf.getvalue()
         self.assertEqual("B\n", output)
 
@@ -367,7 +367,7 @@ class TestObjprint(ObjprintTestCase):
             return f"DerivedClass, {obj.name}"
 
         with io.StringIO() as buf, redirect_stdout(buf):
-            op(DerivedClass(), inherit=True)
+            op(DerivedClass())
             output = buf.getvalue()
         self.assertEqual("DerivedClass, B\n", output)
 

--- a/tests/test_objprint.py
+++ b/tests/test_objprint.py
@@ -345,3 +345,30 @@ class TestObjprint(ObjprintTestCase):
             exec("print(b)")
             output = buf.getvalue()
         self.assertEqual("[1, 2, 3]\n[1, 2, 3]\n", output)
+
+    def test_inherit(self):
+        class BaseClass:
+            name = 'A'
+
+        class DerivedClass(BaseClass):
+            name = 'B'
+
+        @op.register_formatter(BaseClass)
+        def base_formatter(obj: BaseClass) -> str:
+            return obj.name
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            op(DerivedClass(), inherit=True)
+            output = buf.getvalue()
+        self.assertEqual("B\n", output)
+
+        @op.register_formatter(DerivedClass)
+        def derived_formatter(obj: DerivedClass) -> str:
+            return f"DerivedClass, {obj.name}"
+
+        with io.StringIO() as buf, redirect_stdout(buf):
+            op(DerivedClass(), inherit=True)
+            output = buf.getvalue()
+        self.assertEqual("DerivedClass, B\n", output)
+
+        op.unregister_formatter()


### PR DESCRIPTION
### Related Issue

This PR resolves Issue #77 

### Description

I have implemented a `register` function to set custom type formatting functions, and a `unregister` function to remove it.
A decorator `register_type(obj_type)` is also implemented.
Unit tests are included.
Readme is updated.
