### PR TITLE
Improve `CodeType` printing

### DIFF
--- a/src/objprint/objprint.py
+++ b/src/objprint/objprint.py
@@ -175,7 +175,8 @@ class ObjPrint:
         else:
             # It's an object
 
-            # If it has __str__ or __repr__ overloaded, honor that
+            # If it has __str__ or __repr__ overloaded,
+            # honor that(Excepted for CodeType, default __str__ is such unreadable)
             if cfg.honor_existing and \
                     (obj.__class__.__str__ is not object.__str__ or obj.__class__.__repr__ is not object.__repr__) and \
                     not isinstance(obj, CodeType):

--- a/src/objprint/objprint.py
+++ b/src/objprint/objprint.py
@@ -7,7 +7,7 @@ import inspect
 import itertools
 import json
 import re
-from types import FunctionType, FrameType
+from types import FunctionType, FrameType, CodeType
 from typing import Any, Callable, Iterable, List, Optional, Set, TypeVar, Type
 
 from .color_util import COLOR, set_color
@@ -177,7 +177,8 @@ class ObjPrint:
 
             # If it has __str__ or __repr__ overloaded, honor that
             if cfg.honor_existing and \
-                    (obj.__class__.__str__ is not object.__str__ or obj.__class__.__repr__ is not object.__repr__):
+                    (obj.__class__.__str__ is not object.__str__ or obj.__class__.__repr__ is not object.__repr__) and \
+                    not isinstance(obj, CodeType):
                 # Make sure we indent properly
                 s = str(obj)
                 lines = s.split("\n")

--- a/tests/test_objstr.py
+++ b/tests/test_objstr.py
@@ -171,3 +171,9 @@ class TestObjStr(ObjprintTestCase):
         self.assertEqual(s.count("t2"), 1)
         s = objstr(t2, skip_recursion=False, depth=6)
         self.assertEqual(s.count("t2"), 3)
+
+    def test_code_object(self):
+        def _f():
+            pass
+        code_obj = _f.__code__
+        self.assertNotEqual(objstr(code_obj), str(code_obj))


### PR DESCRIPTION
# Summary
`CodeType` in Python has a default `__str__` and `__repr__`, but it is such unreadable, it only show the `co_filename` and `co_firstlineno`.
In this PR, I add a special judge to filter out the `CodeType` object.

## Before this PR:
![image](https://github.com/gaogaotiantian/objprint/assets/120731947/f2dba9a3-380b-4e74-9220-746d95d20912)

## After this PR:
![image](https://github.com/gaogaotiantian/objprint/assets/120731947/d9f68f07-2808-4822-950c-2208fc1dafee)

Issue resolved: #94 