### PR TITLE
Fix built-in method raise exception (#118)

### DIFF
--- a/src/objprint/objprint.py
+++ b/src/objprint/objprint.py
@@ -220,11 +220,17 @@ class ObjPrint:
     def _get_custom_object_str(self, obj: Any, memo: Optional[Set[int]], indent_level: int, cfg: _PrintConfig):
 
         def _get_method_line(attr: str) -> str:
+            try:
+                method_sig = str(inspect.signature(getattr(obj, attr)))
+            except ValueError:
+                # Please consider special handling
+                method_sig = "(<signature unknown>)"
+
             if cfg.color:
                 return f"{set_color('def', COLOR.MAGENTA)} "\
-                    f"{set_color(attr, COLOR.GREEN)}{inspect.signature(getattr(obj, attr))}"
+                    f"{set_color(attr, COLOR.GREEN)}{method_sig}"
             else:
-                return f"def {attr}{inspect.signature(getattr(obj, attr))}"
+                return f"def {attr}{method_sig}"
 
         def _get_line(key: str) -> str:
             val = self._objstr(getattr(obj, key), memo, indent_level + 1, cfg)

--- a/tests/test_objstr.py
+++ b/tests/test_objstr.py
@@ -171,3 +171,25 @@ class TestObjStr(ObjprintTestCase):
         self.assertEqual(s.count("t2"), 1)
         s = objstr(t2, skip_recursion=False, depth=6)
         self.assertEqual(s.count("t2"), 3)
+
+    def test_builtin_method(self):
+        # for test https://github.com/gaogaotiantian/objprint/issues/118
+        import sys
+
+        t1 = b""
+        s = objstr(t1, print_methods=True, honor_existing=False)
+        is_python_le_3_13 = sys.version_info <= (3, 13)
+        if is_python_le_3_13:
+            self.assertIn("<signature unknown>", s)
+        else:
+            self.assertNotIn("<signature unknown>", s)
+
+        def custom_hex(self):
+            print("custom hex")
+
+        def custom_capitalize(self):
+            print("custom capitalize")
+
+        t2 = ObjTest({"hex": custom_hex, "capitalize": custom_capitalize})
+        s = objstr(t2, print_methods=True)
+        self.assertNotIn("<signature unknown>", s)


### PR DESCRIPTION
针对 #118 中提出的问题尝试做了改善，避免因`inspect.signature`问题，导致自己库抛出异常。
同步增加了相应的测试用例。